### PR TITLE
Add a field 'conceptSeeAlso' in addition to conceptURI and conceptName

### DIFF
--- a/src/commons.coffee
+++ b/src/commons.coffee
@@ -1,5 +1,4 @@
 # these common classes + methods are used by the plugins, developed by the vzg: gnd, geonames, gn250, gvk, georef, dante
-
 class CustomDataTypeWithCommons extends CustomDataType
 
   # custom style to head
@@ -59,10 +58,9 @@ class CustomDataTypeWithCommons extends CustomDataType
 
   getFieldNames: ->
 
-      field_names = [
+      return [
           @fullName()+".conceptURI"
           @fullName()+".conceptName"
-          @fullName()+".conceptSeeAlso"
       ]
 
       #for lang in ez5.session.getPref("search_languages")
@@ -123,7 +121,6 @@ class CustomDataTypeWithCommons extends CustomDataType
       cdata = {
             conceptName : ''
             conceptURI : ''
-            conceptSeeAlso : ''
         }
       data[@name()] = cdata
     else
@@ -158,7 +155,6 @@ class CustomDataTypeWithCommons extends CustomDataType
                         cdata = {
                               conceptName : ''
                               conceptURI : ''
-                              conceptSeeAlso : ''
                         }
                         data[@name()] = cdata
                         # trigger form change
@@ -228,7 +224,6 @@ class CustomDataTypeWithCommons extends CustomDataType
       return {
         conceptName : 'Example'
         conceptURI : 'https://example.com'
-        conceptSeeAlso : 'Beispiel,Exemplo,Instance'
       }
 
     cdata = data[@name()] or data._template?[@name()]
@@ -241,13 +236,12 @@ class CustomDataTypeWithCommons extends CustomDataType
         save_data[@name()] = null
 
       when "ok"
-        field_value = {}
-        ;['conceptName', 'conceptURI', 'conceptSeeAlso'].map (n) ->
-          field_value[n] = if cdata[n] then cdata[n].trim() else ""
-        save_data[@name()] = Object.assign field_value,
+        save_data[@name()] =
+          conceptName: cdata.conceptName.trim()
+          conceptURI: cdata.conceptURI.trim()
           _fulltext:
-            text: field_value.conceptName + " " + field_value.conceptSeeAlso
-            string: field_value.conceptURI
+                  text: cdata.conceptName.trim()
+                  string: cdata.conceptURI.trim()
 
 
   #######################################################################
@@ -299,14 +293,12 @@ class CustomDataTypeWithCommons extends CustomDataType
           cdata = {
                 conceptName : ''
                 conceptURI : ''
-                conceptSeeAlso: ''
             }
           return "empty"
     else
       cdata = {
             conceptName : ''
             conceptURI : ''
-            conceptSeeAlso: ''
         }
       return "empty"
 
@@ -351,6 +343,137 @@ class CustomDataTypeCommonFacet extends FieldFacet
       fields: [ @_field.fullName()+".conceptName" ]
       type: "in"
       in: [ obj.term ]
+
+class CustomDataTypeWithCommonsSeeAlso extends CustomDataTypeWithCommons
+
+  getFieldNames: ->
+      return [
+          @fullName()+".conceptURI"
+          @fullName()+".conceptName"
+          @fullName()+".conceptSeeAlso"
+      ]
+
+  #######################################################################
+  # handle editorinput
+  renderEditorInput: (data, top_level_data, opts) ->
+
+    if not data[@name()]
+      cdata = {
+            conceptName : ''
+            conceptURI : ''
+            conceptSeeAlso : ''
+        }
+      data[@name()] = cdata
+    else
+      cdata = data[@name()]
+
+    @__renderEditorInputPopover(data, cdata)
+
+
+  __renderEditorInputPopover: (data, cdata) ->
+
+    layout = new CUI.HorizontalLayout
+      left:
+        content:
+            new CUI.Buttonbar(
+              buttons: [
+                  new CUI.Button
+                      text: ""
+                      icon: 'edit'
+                      group: "groupA"
+
+                      onClick: (ev, btn) =>
+                        @showEditPopover(btn, cdata, layout)
+
+                  new CUI.Button
+                      text: ""
+                      icon: 'trash'
+                      group: "groupA"
+                      onClick: (ev, btn) =>
+                        # delete data
+                        cdata = {
+                              conceptName : ''
+                              conceptURI : ''
+                              conceptSeeAlso : ''
+                        }
+                        data[@name()] = cdata
+                        # trigger form change
+                        @__updateResult(cdata, layout)
+                        CUI.Events.trigger
+                          node: @__layout
+                          type: "editor-changed"
+                        CUI.Events.trigger
+                          node: layout
+                          type: "editor-changed"
+              ]
+            )
+      center: {}
+      right: {}
+    @__updateResult(cdata, layout)
+    layout
+
+
+  #######################################################################
+  # is called, when record is being saved by user
+  getSaveData: (data, save_data, opts) ->
+    if opts.demo_data
+      # return demo data here
+      return {
+        conceptName : 'Example'
+        conceptURI : 'https://example.com'
+        conceptSeeAlso : 'Beispiel,Exemplo,Instance'
+      }
+
+    cdata = data[@name()] or data._template?[@name()]
+
+    switch @getDataStatus(cdata)
+      when "invalid"
+        throw InvalidSaveDataException
+
+      when "empty"
+        save_data[@name()] = null
+
+      when "ok"
+        field_value = {}
+        ;['conceptName', 'conceptURI', 'conceptSeeAlso'].map (n) ->
+          field_value[n] = if cdata[n] then cdata[n].trim() else ""
+        save_data[@name()] = Object.assign field_value,
+          _fulltext:
+            text: field_value.conceptName + " " + field_value.conceptSeeAlso
+            string: field_value.conceptURI
+
+  #######################################################################
+  # checks the form and returns status
+  getDataStatus: (cdata) ->
+    if (cdata)
+        if cdata.conceptURI and cdata.conceptName
+          # check url for valididy
+          uriCheck = CUI.parseLocation(cdata.conceptURI)
+
+          nameCheck = if cdata.conceptName then cdata.conceptName.trim() else undefined
+
+          if uriCheck and nameCheck
+            return "ok"
+
+          if cdata.conceptURI.trim() == '' and cdata.conceptName.trim() == ''
+            return "empty"
+
+          return "invalid"
+        else
+          cdata = {
+                conceptName : ''
+                conceptURI : ''
+                conceptSeeAlso: ''
+            }
+          return "empty"
+    else
+      cdata = {
+            conceptName : ''
+            conceptURI : ''
+            conceptSeeAlso: ''
+        }
+      return "empty"
+
 
 
 # vim: sw=2 et

--- a/src/commons.coffee
+++ b/src/commons.coffee
@@ -246,8 +246,8 @@ class CustomDataTypeWithCommons extends CustomDataType
           field_value[n] = if cdata[n] then cdata[n].trim() else ""
         save_data[@name()] = Object.assign field_value,
           _fulltext:
-            text: save_data.conceptName + save_data.conceptSeeAlso
-            string: save_data.conceptURI
+            text: field_value.conceptName + " " + field_value.conceptSeeAlso
+            string: field_value.conceptURI
 
 
   #######################################################################

--- a/src/commons.coffee
+++ b/src/commons.coffee
@@ -62,6 +62,7 @@ class CustomDataTypeWithCommons extends CustomDataType
       field_names = [
           @fullName()+".conceptURI"
           @fullName()+".conceptName"
+          @fullName()+".conceptSeeAlso"
       ]
 
       #for lang in ez5.session.getPref("search_languages")
@@ -122,6 +123,7 @@ class CustomDataTypeWithCommons extends CustomDataType
       cdata = {
             conceptName : ''
             conceptURI : ''
+            conceptSeeAlso : ''
         }
       data[@name()] = cdata
     else
@@ -156,6 +158,7 @@ class CustomDataTypeWithCommons extends CustomDataType
                         cdata = {
                               conceptName : ''
                               conceptURI : ''
+                              conceptSeeAlso : ''
                         }
                         data[@name()] = cdata
                         # trigger form change
@@ -225,6 +228,7 @@ class CustomDataTypeWithCommons extends CustomDataType
       return {
         conceptName : 'Example'
         conceptURI : 'https://example.com'
+        conceptSeeAlso : 'Beispiel,Exemplo,Instance'
       }
 
     cdata = data[@name()] or data._template?[@name()]
@@ -237,12 +241,13 @@ class CustomDataTypeWithCommons extends CustomDataType
         save_data[@name()] = null
 
       when "ok"
-        save_data[@name()] =
-          conceptName: cdata.conceptName.trim()
-          conceptURI: cdata.conceptURI.trim()
+        field_value = {}
+        ;['conceptName', 'conceptURI', 'conceptSeeAlso'].map (n) ->
+          field_value[n] = if cdata[n] then cdata[n].trim() else ""
+        save_data[@name()] = Object.assign field_value,
           _fulltext:
-                  text: cdata.conceptName.trim()
-                  string: cdata.conceptURI.trim()
+            text: save_data.conceptName + save_data.conceptSeeAlso
+            string: save_data.conceptURI
 
 
   #######################################################################
@@ -294,12 +299,14 @@ class CustomDataTypeWithCommons extends CustomDataType
           cdata = {
                 conceptName : ''
                 conceptURI : ''
+                conceptSeeAlso: ''
             }
           return "empty"
     else
       cdata = {
             conceptName : ''
             conceptURI : ''
+            conceptSeeAlso: ''
         }
       return "empty"
 
@@ -346,3 +353,4 @@ class CustomDataTypeCommonFacet extends FieldFacet
       in: [ obj.term ]
 
 
+# vim: sw=2 et

--- a/tools/base-plugins.make
+++ b/tools/base-plugins.make
@@ -1,4 +1,5 @@
 WEB = build/webfrontend
+COFFEE = ./node_modules/.bin/coffee
 L10N2JSON ?= easydb-l10n2json.py
 
 JS ?= $(WEB)/${PLUGIN_NAME}.js
@@ -20,7 +21,7 @@ build-stamp-l10n: $(L10N_FILES)
 	touch $@
 
 %.coffee.js: %.coffee
-	coffee -b -p --compile "$^" > "$@" || ( rm -f "$@" ; false )
+	${COFFEE} -b -p --compile "$^" > "$@" || ( rm -f "$@" ; false )
 
 $(WEB)/%: src/webfrontend/%
 	mkdir -p $(dir $@)


### PR DESCRIPTION
This adds a third field `conceptSeeAlso` to the concept object.

We use it to store additional data about a concept (such as variant names, short form of identifier) that should be searchable in easydb but not necessarily displayed to the user.